### PR TITLE
Allow unprotected branches

### DIFF
--- a/modules/repository_base/README.md
+++ b/modules/repository_base/README.md
@@ -43,7 +43,7 @@ No modules.
 | <a name="input_has_wiki"></a> [has\_wiki](#input\_has\_wiki) | Enables Github Wiki for the repository | `bool` | `true` | no |
 | <a name="input_homepage"></a> [homepage](#input\_homepage) | The homepage for the repository | `string` | `""` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name of the repository to create/import. | `string` | n/a | yes |
-| <a name="input_protected_branches"></a> [protected\_branches](#input\_protected\_branches) | A list of ref names or patterns that should be protected. Defaults `["main"]` | `list(string)` | <pre>[<br>  "main"<br>]</pre> | no |
+| <a name="input_protected_branches"></a> [protected\_branches](#input\_protected\_branches) | A list of ref names or patterns that should be protected. Setting to `[]` means no protection. Defaults `["~DEFAULT_BRANCH"]` | `list(string)` | <pre>[<br>  "~DEFAULT_BRANCH"<br>]</pre> | no |
 | <a name="input_repository_team_permissions"></a> [repository\_team\_permissions](#input\_repository\_team\_permissions) | A map where the keys are github team ids and the value is the permissions the team should have in the repository | `map(string)` | n/a | yes |
 | <a name="input_secret_scanning"></a> [secret\_scanning](#input\_secret\_scanning) | Enables secret scanning for the repository. If repository is private `advance_security` must also be enabled. | `bool` | `true` | no |
 | <a name="input_secret_scanning_on_push"></a> [secret\_scanning\_on\_push](#input\_secret\_scanning\_on\_push) | Enables secret scanning push protection for the repository. If repository is private `advance_security` must also be enabled. | `bool` | `true` | no |

--- a/modules/repository_base/repository.tf
+++ b/modules/repository_base/repository.tf
@@ -74,7 +74,7 @@ resource "github_repository_ruleset" "protected_branch_base_rules" {
   conditions {
     ref_name {
       exclude = []
-      include = toset(concat(["~DEFAULT_BRANCH"], local.protected_branches_refs))
+      include = toset(local.protected_branches_refs)
     }
   }
 }

--- a/modules/repository_base/variables.tf
+++ b/modules/repository_base/variables.tf
@@ -22,8 +22,8 @@ variable "repository_team_permissions" {
 
 variable "protected_branches" {
   type        = list(string)
-  description = "A list of ref names or patterns that should be protected. Defaults `[\"main\"]`"
-  default     = ["main"]
+  description = "A list of ref names or patterns that should be protected. Setting to `[]` means no protection. Defaults `[\"~DEFAULT_BRANCH\"]`"
+  default     = ["~DEFAULT_BRANCH"]
 }
 
 variable "has_downloads" {


### PR DESCRIPTION
---
### ISSUE

#2 Create a repo where we can push to trunk/main

A situation arose, where a default branch with no `branch-protection` be created, when necessary.

---

### CHANGE

This change:

- Removes the default behaviour of adding the `default_branch` to the list of protected branches
- Setting the variable explicitly to an empty list (`protected_branches = []`) disables all branch protection
- Not setting this variable has the behaviour of setting the `default_branch` as a protected branch

---