### PR TITLE
Adds ability to create a README file for the org

### DIFF
--- a/modules/foundations-github-organization/README.md
+++ b/modules/foundations-github-organization/README.md
@@ -9,6 +9,8 @@
 
 | Name | Version |
 |------|---------|
+| <a name="provider_file"></a> [file](#provider\_file) | n/a |
+| <a name="provider_github"></a> [github](#provider\_github) | 5.44.0 |
 | <a name="provider_github.enterprise_scoped"></a> [github.enterprise\_scoped](#provider\_github.enterprise\_scoped) | 5.44.0 |
 | <a name="provider_github.foundation_org_scoped"></a> [github.foundation\_org\_scoped](#provider\_github.foundation\_org\_scoped) | 5.44.0 |
 
@@ -34,7 +36,9 @@ No modules.
 | [github_repository.organizations_repo](https://registry.terraform.io/providers/hashicorp/github/5.44.0/docs/resources/repository) | resource |
 | [github_repository_collaborators.bootstrap_repo_collaborators](https://registry.terraform.io/providers/hashicorp/github/5.44.0/docs/resources/repository_collaborators) | resource |
 | [github_repository_collaborators.organization_repo_collaborators](https://registry.terraform.io/providers/hashicorp/github/5.44.0/docs/resources/repository_collaborators) | resource |
+| [github_repository_file.main_readme](https://registry.terraform.io/providers/hashicorp/github/5.44.0/docs/resources/repository_file) | resource |
 | [github_team.foundation_devs](https://registry.terraform.io/providers/hashicorp/github/5.44.0/docs/resources/team) | resource |
+| [file_file.main_readme](https://registry.terraform.io/providers/hashicorp/file/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -50,6 +54,7 @@ No modules.
 | <a name="input_gcp_tf_state_bucket_project_id"></a> [gcp\_tf\_state\_bucket\_project\_id](#input\_gcp\_tf\_state\_bucket\_project\_id) | The id of the gcp project where the tf state bucket was setup. | `string` | n/a | yes |
 | <a name="input_github_foundations_organization_name"></a> [github\_foundations\_organization\_name](#input\_github\_foundations\_organization\_name) | The name of the organization to create. | `string` | n/a | yes |
 | <a name="input_organization_workload_identity_sa"></a> [organization\_workload\_identity\_sa](#input\_organization\_workload\_identity\_sa) | The service account to use for the organization repository oidc. | `string` | n/a | yes |
+| <a name="input_readme_path"></a> [readme\_path](#input\_readme\_path) | Local Path to the README file in your current codebase. Pushed to the github foundation repository. | `string` | `""` | no |
 | <a name="input_workload_identity_provider_name"></a> [workload\_identity\_provider\_name](#input\_workload\_identity\_provider\_name) | The name of the workload identity provider to use for the oidc of the github foundation repositories. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/foundations-github-organization/repo_readme.tf
+++ b/modules/foundations-github-organization/repo_readme.tf
@@ -1,0 +1,12 @@
+data "file" "main_readme" {
+  filename = var.readme_path
+}
+
+resource "github_repository_file" "main_readme" {
+  # Only create this when the readme filename is not empty
+  count      = var.readme_path != "" ? 1 : 0
+  repository = github_repository.organizations_repo.name
+  file       = "README.md"
+  content    = data.file.main_readme.content
+  depends_on = [github_repository.organizations_repo]
+}

--- a/modules/foundations-github-organization/variables.tf
+++ b/modules/foundations-github-organization/variables.tf
@@ -53,3 +53,9 @@ variable "bucket_location" {
   type        = string
   description = "The location of the tf state bucket."
 }
+
+variable "readme_path" {
+  type        = string
+  description = "Local Path to the README file in your current codebase. Pushed to the github foundation repository."
+  default     = ""
+}


### PR DESCRIPTION
---

### ISSUE

#25: We need to add documentation for the users on how to setup the repositories ad teams. This feature adds the ability to create a README file when the `organizations` repository is created.

---