### PR TITLE
Fix bugs in secret loops

### DIFF
--- a/modules/organization_secrets/secrets.tf
+++ b/modules/organization_secrets/secrets.tf
@@ -3,7 +3,7 @@ locals {
   sanitized_action_secrets = merge(
     var.organization_action_secrets,
     {
-      for k, v in var.var.organization_action_secrets : k => {
+      for k, v in var.organization_action_secrets : k => {
         encrypted_value       = v.encrypted_value
         visibility            = v.visibility
         selected_repositories = coalesce(v.selected_repositories, [])

--- a/modules/repository_base/README.md
+++ b/modules/repository_base/README.md
@@ -27,7 +27,7 @@ No modules.
 | [github_repository.repository](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository) | resource |
 | [github_repository_collaborators.collaborators](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository_collaborators) | resource |
 | [github_repository_dependabot_security_updates.automated_security_fixes](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository_dependabot_security_updates) | resource |
-| [github_repository_environment.environemnt](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository_environment) | resource |
+| [github_repository_environment.environment](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository_environment) | resource |
 | [github_repository_ruleset.protected_branch_base_rules](https://registry.terraform.io/providers/integrations/github/5.42.0/docs/resources/repository_ruleset) | resource |
 
 ## Inputs

--- a/modules/repository_base/environments.tf
+++ b/modules/repository_base/environments.tf
@@ -1,5 +1,5 @@
 resource "github_repository_environment" "environemnt" {
-  for_each    = toset(keys(var.environments))
+  for_each    = toset(keys(coalesce(var.environments, {})))
   repository  = github_repository.repository.name
   environment = each.value
 }

--- a/modules/repository_base/environments.tf
+++ b/modules/repository_base/environments.tf
@@ -1,4 +1,4 @@
-resource "github_repository_environment" "environemnt" {
+resource "github_repository_environment" "environment" {
   for_each    = toset(keys(coalesce(var.environments, {})))
   repository  = github_repository.repository.name
   environment = each.value

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,10 +1,10 @@
 locals {
   environment_actions_secrets = flatten([
-    for env_name, env in coalesce(var.environments, {}) : tolist([for secret_name, secret in env.action_secrets : {
+    for env_name, env in coalesce(var.environments, {}) : [for secret_name, secret in env.action_secrets : {
       name            = secret_name
       encrypted_value = secret
       environment     = env_name
-    }]) if env.action_secrets != null
+    }] if env.action_secrets != null
   ])
 }
 

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,6 +1,6 @@
 locals {
   action_secrets_per_environment = {
-    for env_name, env in coalesce(var.environments, {}): env_name => [ for secret_name, secret_value in env.var.action_secrets : { name = secret_name, encrypted_value = secret_value}] if env.action_secrets != null
+    for env_name, env in coalesce(var.environments, {}): env_name => [ for secret_name, secret_value in env.action_secrets : { name = secret_name, encrypted_value = secret_value}] if env.action_secrets != null
   }
   
   environment_action_secrets = {

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -39,9 +39,8 @@ resource "github_dependabot_secret" "dependabot_secret" {
 
 resource "github_actions_environment_secret" "environment_secret" {
   for_each        = local.environment_action_secrets_map
-  depends_on = [ github_repository_environment.environemnt["${each.value.environment}"] ]
   repository      = var.name
-  environment     = each.value.environment
+  environment     = github_repository_environment.environment["${each.value.environment}"].environment
   encrypted_value = each.value.encrypted_value
   secret_name     = each.value.name
 }

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,11 +1,11 @@
 locals {
-  environment_actions_secrets = flatten(flatten([
-    for env_name, env in coalesce(var.environments, {}) : [for secret_name, secret in env.action_secrets : {
+  environment_actions_secrets = flatten([
+    for env_name, env in coalesce(var.environments, {}) : tolist([for secret_name, secret in env.action_secrets : {
       name            = secret_name
       encrypted_value = secret
       environment     = env_name
-    }] if env.action_secrets != null 
-  ]))
+    }]) if env.action_secrets != null
+  ])
 }
 
 resource "github_actions_secret" "actions_secret" {

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -6,9 +6,9 @@ locals {
   # Terraform can't loop over a list of objects so we convert it into a map
   environment_action_secrets_map = {
     for environment_secret in local.environment_action_secrets_list : "${environment_secret.environment}:${environment_secret.name}" => {
-      environment = environment_secret.environment
-      name        = environment_secret.name
-      value       = environment_secret.encrypted_value
+      environment     = environment_secret.environment
+      name            = environment_secret.name
+      encrypted_value = environment_secret.encrypted_value
     }
   }
 }

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,15 +1,15 @@
 locals {
-  environment_actions_secrets = try(concat(values({
-    for env_name, env in var.environments : env_name => [for secret_name, secret in env.action_secrets : {
+  environment_actions_secrets = concat(values({
+    for env_name, env in coalesce(var.environments, {}) : env_name => [for secret_name, secret in env.action_secrets : {
       name            = secret_name
       encrypted_value = secret
       environment     = env_name
     }] if env.action_secrets != null 
-  })), [])
+  }))
 }
 
 resource "github_actions_secret" "actions_secret" {
-  for_each = var.action_secrets
+  for_each = coalesce(var.action_secrets, {})
 
   repository      = github_repository.repository.name
   secret_name     = each.key
@@ -17,7 +17,7 @@ resource "github_actions_secret" "actions_secret" {
 }
 
 resource "github_codespaces_secret" "codespaces_secret" {
-  for_each = var.codespace_secrets
+  for_each = coalesce(var.codespace_secrets, {})
 
   repository      = github_repository.repository.name
   secret_name     = each.key
@@ -25,7 +25,7 @@ resource "github_codespaces_secret" "codespaces_secret" {
 }
 
 resource "github_dependabot_secret" "dependabot_secret" {
-  for_each = var.dependabot_secrets
+  for_each = coalesce(var.dependabot_secrets, {})
 
   repository      = github_repository.repository.name
   secret_name     = each.key

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -39,6 +39,7 @@ resource "github_dependabot_secret" "dependabot_secret" {
 
 resource "github_actions_environment_secret" "environment_secret" {
   for_each        = local.environment_action_secrets_map
+  depends_on = [ github_repository_environment.environemnt[*] ]
   repository      = var.name
   environment     = each.value.environment
   encrypted_value = each.value.encrypted_value

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,11 +1,11 @@
 locals {
-  environment_actions_secrets = concat(values({
-    for env_name, env in coalesce(var.environments, {}) : env_name => [for secret_name, secret in env.action_secrets : {
+  environment_actions_secrets = flatten([
+    for env_name, env in coalesce(var.environments, {}) : [for secret_name, secret in env.action_secrets : {
       name            = secret_name
       encrypted_value = secret
       environment     = env_name
     }] if env.action_secrets != null 
-  }))
+  ])
 }
 
 resource "github_actions_secret" "actions_secret" {

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -33,7 +33,7 @@ resource "github_dependabot_secret" "dependabot_secret" {
 }
 
 resource "github_actions_environment_secret" "environment_secret" {
-  for_each        = local.environment_actions_secrets
+  for_each        = toset(local.environment_actions_secrets)
   repository      = var.name
   environment     = each.value.environment
   encrypted_value = each.value.encrypted_value

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -39,7 +39,7 @@ resource "github_dependabot_secret" "dependabot_secret" {
 
 resource "github_actions_environment_secret" "environment_secret" {
   for_each        = local.environment_action_secrets_map
-  depends_on = [ github_repository_environment.environemnt[*] ]
+  depends_on = [ github_repository_environment.environemnt["${each.value.environment}"] ]
   repository      = var.name
   environment     = each.value.environment
   encrypted_value = each.value.encrypted_value

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -1,11 +1,11 @@
 locals {
-  environment_actions_secrets = flatten([
+  environment_actions_secrets = flatten(flatten([
     for env_name, env in coalesce(var.environments, {}) : [for secret_name, secret in env.action_secrets : {
       name            = secret_name
       encrypted_value = secret
       environment     = env_name
     }] if env.action_secrets != null 
-  ])
+  ]))
 }
 
 resource "github_actions_secret" "actions_secret" {

--- a/modules/repository_base/secrets.tf
+++ b/modules/repository_base/secrets.tf
@@ -5,7 +5,7 @@ locals {
 
   # Terraform can't loop over a list of objects so we convert it into a map
   environment_action_secrets_map = {
-    for environment_secret in local.environment_action_secrets_list : "${env_name}:${environment_secret.name}" => {
+    for environment_secret in local.environment_action_secrets_list : "${environment_secret.environment}:${environment_secret.name}" => {
       environment = environment_secret.environment
       name        = environment_secret.name
       value       = environment_secret.encrypted_value


### PR DESCRIPTION
Secret loops were failing because of null values and attempting to loop over a list of objects. Following fixes:
- coalesced null values to empty defaults
- changed list of objects to a map of objects. Because terraform can apparently loop over those but not lists