### PR TITLE
feat: add pre-commit hooks to check formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.18.3
+    hooks:
+    -   id: commitizen
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-added-large-files
+    -   id: detect-private-key
+-   repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.88.1
+    hooks:
+    -   id: terraform_fmt
+        args:
+            - --args=-check
+            - --args=-diff
+    -   id: terraform_tflint
+    -   id: terraform_validate
+        args:
+            - --hook-config=--retry-once-with-cleanup=true
+    -   id: terraform_trivy # static analysis of security settings in your Terraform code
+        args:
+            - --args=--skip-dirs="**/.terraform"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,7 @@ repos:
     -   id: end-of-file-fixer
     -   id: check-added-large-files
     -   id: detect-private-key
+    exclude: .*/\.terraform/.*
 -   repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.88.1
     hooks:
@@ -21,8 +22,6 @@ repos:
             - --args=-diff
     -   id: terraform_tflint
     -   id: terraform_validate
-        args:
-            - --hook-config=--retry-once-with-cleanup=true
     -   id: terraform_trivy # static analysis of security settings in your Terraform code
         args:
             - --args=--skip-dirs="**/.terraform"

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,0 +1,5 @@
+config {
+  ignore_module = {
+    "organizations/tools" = true
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,110 @@
+# Contributing to the The GitHub Foundations Toolkit
+
+We welcome contributions to the GitHub Foundations Toolkit. Please read these Contributing Guidelines for more information on how to get started.
+
+## How to contribute
+
+We welcome contributions from the community and are happy to have you as a contributor. Here are a few ways you can contribute:
+
+- [Reporting issues](#reporting-issues)
+- [Conventional Commits](#conventional-commits)
+- [Submitting pull requests](#submitting-pull-requests)
+- [Providing feedback](#providing-feedback)
+
+### Requirements
+
+You will need the following installed:
+- [Terraform](https://developer.hashicorp.com/terraform/install)
+- [Terragrunt](https://terragrunt.gruntwork.io/docs/getting-started/install/)
+- [terraform-docs](https://github.com/terraform-docs/terraform-docs#installation)
+- [Pre-commit](#pre-commit-checks)
+- [TFLint](https://github.com/terraform-linters/tflint)
+- [Trivy](https://aquasecurity.github.io/trivy/v0.49/getting-started/installation/)
+
+#### Installing using Homebrew
+
+To install the above using `homebrew`, do the following:
+
+```bash
+$ brew install terraform terragrunt pre-commit tflint trivy terraform-docs
+```
+
+#### Running the pre-commit checks manually
+
+You can run the pre-commit checks manually. See [here](#pre-commit-checks) for more information.
+
+
+## Reporting issues
+
+If you find a bug or have a feature request, please report it in the [Issues](https://github.com/FociSolutions/github-foundations-modules/issues)
+
+## Conventional Commits
+
+We use [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) to ensure that our commit messages are easy to read and understand. This makes it easier to understand the history of the project and to generate changelogs.
+
+When you submit a pull request, please use conventional commits for your commit messages. This will make it easier for us to understand your changes and to generate changelogs.
+
+The format is:
+
+```
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Where type is one of:
+ - build
+ - ci
+ - docs
+ - feat
+ - fix
+ - perf
+ - refactor
+ - style
+ - test
+ - chore
+ - revert
+ - bump
+
+## Submitting pull requests
+
+If you would like to contribute to the project, please submit a pull request. We will review your pull request and work with you to get it merged.
+
+A pull request description must include:
+* A description of the problem you are solving
+* A description of the solution
+* A description of the testing you have done to verify the solution
+* A description of any documentation updates that were needed
+
+Your pull request must pass all existing tests, and you should add tests for any new functionality you are adding.
+
+### Pre-commit checks
+
+Your changes should also pass the [pre-commit](pre-commit.com) checks. To install pre-commit, see [the installation instructions](https://pre-commit.com/index.html#install).
+
+You can install the pre-commit checks by running
+
+```
+$ pre-commit install
+```
+
+in the root of the repository.
+
+Then, whenever you run `git commit`, the pre-commit checks will run. If any of the checks fail, the commit will be aborted.
+
+If you'd like to run pre-commit on your `staged` files, you can run:
+
+```
+$ pre-commit run
+```
+
+If you would like to run pre-commit across your entire repo, you can run:
+
+```
+$ pre-commit run --all-files
+```
+## Providing feedback
+
+We are always looking for feedback on how we can improve the project. If you have any feedback, please let us know in the [Issues](https://github.com/FociSolutions/github-foundations-modules/issues) or [Discussions](https://github.com/FociSolutions/github-foundations-modules/discussions).

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # github-foundations-modules
 A collection of terraform modules used in the Github Foundations framework.
+
+## Contributing to the toolkit
+
+We welcome contributions to the GitHub Foundations Toolkit. Please read these [Contributing Guidelines](./CONTRIBUTING.md) for more information on how to get started.
+
+## License
+
+The GitHub Foundations Toolkit is licensed under the [MIT License](https://opensource.org/licenses/MIT). Please see the [LICENSE](./LICENSE) file for more information.


### PR DESCRIPTION
---

### ISSUE

[#37](https://github.com/FociSolutions/github-foundations/issues/37) - Add Git Commit hooks to enforce conventional commits

Following [#36](https://github.com/FociSolutions/github-foundations/issues/36) , we decided to enforce [Conventional Commits](https://www.conventionalcommits.org/).
As such, we will require:

* pre-commit git checks
* a `CONTRIBUTING.md` file on how contributions should be made

### CHANGES

This PR includes the following changes:

- Added a CONTRIBUTING.md guide, detailing how to get setup to develop in the repo
- added a script that will run to setup some of the developer environment
- added `pre-commit` to run commit-time checks. This replaces some of the `GitHub Hooks` we had previously
- added the following `pre-commit` checks:
    - `commitizen`: to enforce `Conventional Commits`
    - trailing-whitespace
    - end-of-file-fixer
    - check-added-large-files
    - detect-private-key
    - terraform_fmt
    - terragrunt_fmt
    - terraform_tflint
    - terraform_validate 
    - `terraform_trivy`:  Static analysis of security settings in your Terraform code, using `Trivy`

---