### PR TITLE
Adding AWS OIDC module

### DIFF
--- a/modules/github-aws-oidc/README.md
+++ b/modules/github-aws-oidc/README.md
@@ -1,0 +1,71 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.0.0 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.77 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.0.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_federated_identity_credential.bootstrap_drift_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.bootstrap_pull_request_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.organization_drift_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_federated_identity_credential.organization_pull_request_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
+| [azurerm_resource_group.github_foundations_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.bootstrap_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.organization_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_storage_account.github_foundations_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
+| [azurerm_storage_container.github_foundations_tf_state_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_container.github_foundations_tf_state_encrypted_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
+| [azurerm_storage_encryption_scope.encryption_scope](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_encryption_scope) | resource |
+| [azurerm_user_assigned_identity.bootstrap_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_user_assigned_identity.organization_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
+| [azurerm_resource_group.github_foundations_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_drift_detection_branch_name"></a> [drift\_detection\_branch\_name](#input\_drift\_detection\_branch\_name) | The name of the branch to use for drift detection. | `string` | n/a | yes |
+| <a name="input_github_foundations_organization_name"></a> [github\_foundations\_organization\_name](#input\_github\_foundations\_organization\_name) | The name of the organization that the github foundation repos will be under. | `string` | n/a | yes |
+| <a name="input_kv_name"></a> [kv\_name](#input\_kv\_name) | The name of the key vault to use for github foundation secrets. If storing secrets to authenticate against github in a different way then this does not need to be set. (Optional) | `string` | `""` | no |
+| <a name="input_kv_resource_group"></a> [kv\_resource\_group](#input\_kv\_resource\_group) | The name of the resource group that the key vault is in. If empty it will default to the github foundations resource group. | `string` | n/a | yes |
+| <a name="input_rg_create"></a> [rg\_create](#input\_rg\_create) | Create the resource group. When set to false it uses the `rg_name` input to reference an existing resource group. Defaults to true. | `bool` | `true` | no |
+| <a name="input_rg_location"></a> [rg\_location](#input\_rg\_location) | The location of the resource group to create the github foundation azure resources in. | `string` | n/a | yes |
+| <a name="input_rg_name"></a> [rg\_name](#input\_rg\_name) | The name of the resource group to create the github foundation azure resources in. | `string` | n/a | yes |
+| <a name="input_sa_name"></a> [sa\_name](#input\_sa\_name) | The name of the storage account for github foundations. | `string` | n/a | yes |
+| <a name="input_sa_replication_type"></a> [sa\_replication\_type](#input\_sa\_replication\_type) | The replication type of the storage account for github foundations. Valid options are LRS, GRS, RAGRS, ZRS, GZRS, and RA\_GZRS. Defaults to GRS. | `string` | `"GRS"` | no |
+| <a name="input_sa_tier"></a> [sa\_tier](#input\_sa\_tier) | The tier of the storage account for github foundations. Valid options are Standard and Premium. Defaults to Standard. | `string` | `"Standard"` | no |
+| <a name="input_tf_state_container"></a> [tf\_state\_container](#input\_tf\_state\_container) | The name of the container to store the terraform state file(s) in. | `string` | `"tfstate"` | no |
+| <a name="input_tf_state_container_anonymous_access_level"></a> [tf\_state\_container\_anonymous\_access\_level](#input\_tf\_state\_container\_anonymous\_access\_level) | The anonymous access level of the container to store the terraform state file(s) in. | `string` | `"private"` | no |
+| <a name="input_tf_state_container_default_encryption_scope"></a> [tf\_state\_container\_default\_encryption\_scope](#input\_tf\_state\_container\_default\_encryption\_scope) | The default encryption scope of the container to store the terraform state file(s) in. | <pre>object({<br>    name             = string<br>    source           = string<br>    key_vault_key_id = optional(string)<br>  })</pre> | <pre>{<br>  "name": "",<br>  "source": "",<br>  "storage_account_id": ""<br>}</pre> | no |
+| <a name="input_tf_state_container_encryption_scope_override_enabled"></a> [tf\_state\_container\_encryption\_scope\_override\_enabled](#input\_tf\_state\_container\_encryption\_scope\_override\_enabled) | Whether or not the encryption scope override is enabled for the container to store the terraform state file(s) in. Defaults to false | `bool` | `false` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_bootstrap_client_id"></a> [bootstrap\_client\_id](#output\_bootstrap\_client\_id) | Bootstrap repository client id for authenticating with oidc. |
+| <a name="output_container_name"></a> [container\_name](#output\_container\_name) | Terraform state container name. |
+| <a name="output_key_vault_id"></a> [key\_vault\_id](#output\_key\_vault\_id) | Azure key vault id for github foundation secrets. |
+| <a name="output_organization_client_id"></a> [organization\_client\_id](#output\_organization\_client\_id) | Organizations repository client id for authenticating with oidc. |
+| <a name="output_resource_group"></a> [resource\_group](#output\_resource\_group) | Resource group name. |
+| <a name="output_sa_name"></a> [sa\_name](#output\_sa\_name) | Terraform state container storage account name. |
+| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | Azure subscription id for authenticating with oidc. |
+| <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | Azure tenant id for authenticating with oidc. |

--- a/modules/github-aws-oidc/README.md
+++ b/modules/github-aws-oidc/README.md
@@ -3,15 +3,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
-| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.0.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.77 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=3.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
 
 ## Modules
 
@@ -21,51 +20,36 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [azurerm_federated_identity_credential.bootstrap_drift_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_federated_identity_credential.bootstrap_pull_request_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_federated_identity_credential.organization_drift_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_federated_identity_credential.organization_pull_request_credentials](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/federated_identity_credential) | resource |
-| [azurerm_resource_group.github_foundations_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
-| [azurerm_role_assignment.bootstrap_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_role_assignment.organization_role_assignment](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
-| [azurerm_storage_account.github_foundations_sa](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
-| [azurerm_storage_container.github_foundations_tf_state_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_storage_container.github_foundations_tf_state_encrypted_container](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_container) | resource |
-| [azurerm_storage_encryption_scope.encryption_scope](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_encryption_scope) | resource |
-| [azurerm_user_assigned_identity.bootstrap_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_user_assigned_identity.organization_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
-| [azurerm_key_vault.key_vault](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault) | data source |
-| [azurerm_resource_group.github_foundations_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [aws_dynamodb_table.state_lock_table](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_iam_openid_connect_provider.oidc_provider_entry](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_openid_connect_provider) | resource |
+| [aws_iam_role.organizations_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.organizations_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_kms_key.encryption_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_resourcegroups_group.github_foundations_rg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/resourcegroups_group) | resource |
+| [aws_s3_bucket.state_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.state_bucket_encryption](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.state_bucket_versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_drift_detection_branch_name"></a> [drift\_detection\_branch\_name](#input\_drift\_detection\_branch\_name) | The name of the branch to use for drift detection. | `string` | n/a | yes |
-| <a name="input_github_foundations_organization_name"></a> [github\_foundations\_organization\_name](#input\_github\_foundations\_organization\_name) | The name of the organization that the github foundation repos will be under. | `string` | n/a | yes |
-| <a name="input_kv_name"></a> [kv\_name](#input\_kv\_name) | The name of the key vault to use for github foundation secrets. If storing secrets to authenticate against github in a different way then this does not need to be set. (Optional) | `string` | `""` | no |
-| <a name="input_kv_resource_group"></a> [kv\_resource\_group](#input\_kv\_resource\_group) | The name of the resource group that the key vault is in. If empty it will default to the github foundations resource group. | `string` | n/a | yes |
-| <a name="input_rg_create"></a> [rg\_create](#input\_rg\_create) | Create the resource group. When set to false it uses the `rg_name` input to reference an existing resource group. Defaults to true. | `bool` | `true` | no |
-| <a name="input_rg_location"></a> [rg\_location](#input\_rg\_location) | The location of the resource group to create the github foundation azure resources in. | `string` | n/a | yes |
-| <a name="input_rg_name"></a> [rg\_name](#input\_rg\_name) | The name of the resource group to create the github foundation azure resources in. | `string` | n/a | yes |
-| <a name="input_sa_name"></a> [sa\_name](#input\_sa\_name) | The name of the storage account for github foundations. | `string` | n/a | yes |
-| <a name="input_sa_replication_type"></a> [sa\_replication\_type](#input\_sa\_replication\_type) | The replication type of the storage account for github foundations. Valid options are LRS, GRS, RAGRS, ZRS, GZRS, and RA\_GZRS. Defaults to GRS. | `string` | `"GRS"` | no |
-| <a name="input_sa_tier"></a> [sa\_tier](#input\_sa\_tier) | The tier of the storage account for github foundations. Valid options are Standard and Premium. Defaults to Standard. | `string` | `"Standard"` | no |
-| <a name="input_tf_state_container"></a> [tf\_state\_container](#input\_tf\_state\_container) | The name of the container to store the terraform state file(s) in. | `string` | `"tfstate"` | no |
-| <a name="input_tf_state_container_anonymous_access_level"></a> [tf\_state\_container\_anonymous\_access\_level](#input\_tf\_state\_container\_anonymous\_access\_level) | The anonymous access level of the container to store the terraform state file(s) in. | `string` | `"private"` | no |
-| <a name="input_tf_state_container_default_encryption_scope"></a> [tf\_state\_container\_default\_encryption\_scope](#input\_tf\_state\_container\_default\_encryption\_scope) | The default encryption scope of the container to store the terraform state file(s) in. | <pre>object({<br>    name             = string<br>    source           = string<br>    key_vault_key_id = optional(string)<br>  })</pre> | <pre>{<br>  "name": "",<br>  "source": "",<br>  "storage_account_id": ""<br>}</pre> | no |
-| <a name="input_tf_state_container_encryption_scope_override_enabled"></a> [tf\_state\_container\_encryption\_scope\_override\_enabled](#input\_tf\_state\_container\_encryption\_scope\_override\_enabled) | Whether or not the encryption scope override is enabled for the container to store the terraform state file(s) in. Defaults to false | `bool` | `false` | no |
+| <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the s3 bucket that will store terraform state. | `string` | `"GithubFoundationState"` | no |
+| <a name="input_github_repo_owner"></a> [github\_repo\_owner](#input\_github\_repo\_owner) | The owner of the github foundations organizations repository. This value should be whatever github account you plan to make the repository under. | `string` | n/a | yes |
+| <a name="input_github_thumbprints"></a> [github\_thumbprints](#input\_github\_thumbprints) | A list of top intermediate certifact authority thumbprints to use for setting up an openid connect provider with github. Info on how to obtain thumbprints here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html | `list(string)` | n/a | yes |
+| <a name="input_organizations_repo_name"></a> [organizations\_repo\_name](#input\_organizations\_repo\_name) | The name of the github foundations organizations repository. Defaults to `organizations` | `string` | `"organizations"` | no |
+| <a name="input_organizations_role_name"></a> [organizations\_role\_name](#input\_organizations\_role\_name) | The name of the role that will be assummed by the github runner for the organizations repository. | `string` | `"GhFoundationsOrganizationsAction"` | no |
+| <a name="input_rg_name"></a> [rg\_name](#input\_rg\_name) | The name of the AWS resource group to create for github foundation resources. | `string` | `"GithubFoundationResources"` | no |
+| <a name="input_tflock_db_billing_mode"></a> [tflock\_db\_billing\_mode](#input\_tflock\_db\_billing\_mode) | The billing mode to use for the dynamodb table storing lock file ids. Defaults to `PROVISIONED`. | `string` | `"PROVISIONED"` | no |
+| <a name="input_tflock_db_name"></a> [tflock\_db\_name](#input\_tflock\_db\_name) | The name of the dynamodb table that will store lock file ids. | `string` | `"TFLockIds"` | no |
+| <a name="input_tflock_db_read_capacity"></a> [tflock\_db\_read\_capacity](#input\_tflock\_db\_read\_capacity) | The read capacity to set for the dynamodb table storing lock file ids. Only required if billing mode is `PROVISIONED`. Defaults to 20. | `number` | `20` | no |
+| <a name="input_tflock_db_write_capacity"></a> [tflock\_db\_write\_capacity](#input\_tflock\_db\_write\_capacity) | The write capacity to set for the dynamodb table storing lock file ids. Only required if billing mode is `PROVISIONED`. Defaults to 20. | `number` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_bootstrap_client_id"></a> [bootstrap\_client\_id](#output\_bootstrap\_client\_id) | Bootstrap repository client id for authenticating with oidc. |
-| <a name="output_container_name"></a> [container\_name](#output\_container\_name) | Terraform state container name. |
-| <a name="output_key_vault_id"></a> [key\_vault\_id](#output\_key\_vault\_id) | Azure key vault id for github foundation secrets. |
-| <a name="output_organization_client_id"></a> [organization\_client\_id](#output\_organization\_client\_id) | Organizations repository client id for authenticating with oidc. |
-| <a name="output_resource_group"></a> [resource\_group](#output\_resource\_group) | Resource group name. |
-| <a name="output_sa_name"></a> [sa\_name](#output\_sa\_name) | Terraform state container storage account name. |
-| <a name="output_subscription_id"></a> [subscription\_id](#output\_subscription\_id) | Azure subscription id for authenticating with oidc. |
-| <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | Azure tenant id for authenticating with oidc. |
+| <a name="output_dynamodb_table_name"></a> [dynamodb\_table\_name](#output\_dynamodb\_table\_name) | The name of the dynamodb table that was created to store lock file ids. |
+| <a name="output_organizations_runner_role"></a> [organizations\_runner\_role](#output\_organizations\_runner\_role) | The ARN of the role that the github action runner should assume for the organizations repo |
+| <a name="output_s3_bucket_name"></a> [s3\_bucket\_name](#output\_s3\_bucket\_name) | The name of the s3 bucket holding terraform state. |
+| <a name="output_s3_bucket_region"></a> [s3\_bucket\_region](#output\_s3\_bucket\_region) | The region the s3 bucket holding terraform state was created in. |

--- a/modules/github-aws-oidc/oidc.tf
+++ b/modules/github-aws-oidc/oidc.tf
@@ -52,13 +52,15 @@ resource "aws_iam_role_policy" "organizations_role_policy" {
                     "s3:*"
                 ]
                 Effect = "Allow"
-                Resource = [aws_s3_bucket.state_bucket.arn]
+                Resource = [
+                    aws_s3_bucket.state_bucket.arn,
+                    "${aws_s3_bucket.sate_bucket.arn}/*"    
+                ]
             },
             {
                 Sid = "StateBucketDeleteDeny"
                 Action = [
-                    "s3:DeleteBucket",
-                    "s3:CopyObject"
+                    "s3:DeleteBucket"
                 ]
                 Effect = "Deny"
                 Resource = [aws_s3_bucket.state_bucket.arn]

--- a/modules/github-aws-oidc/oidc.tf
+++ b/modules/github-aws-oidc/oidc.tf
@@ -1,0 +1,95 @@
+resource "aws_iam_openid_connect_provider" "oidc_provider_entry" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = [ "sts.amazonaws.com" ]
+
+  thumbprint_list = var.github_thumbprints
+
+  tags = local.rg_tags
+}
+
+resource "aws_iam_role" "organizations_role" {
+    name = var.organizations_role_name
+
+    assume_role_policy = jsonencode({
+    "Version" = "2012-10-17",
+    "Statement" = [
+        {
+            "Effect" = "Allow",
+            "Action" = "sts:AssumeRoleWithWebIdentity",
+            "Principal" = {
+                "Federated" = aws_iam_openid_connect_provider.oidc_provider_entry.arn
+            },
+            "Condition" = {
+                "StringEquals" = {
+                    "token.actions.githubusercontent.com:aud" = [
+                        "sts.amazonaws.com"
+                    ]
+                },
+                "StringLike" = {
+                    "token.actions.githubusercontent.com:sub": [
+                        "repo:${var.github_repo_owner}/${var.organizations_repo_name}:*"
+                    ]
+                }
+            }
+        }
+    ]
+})
+
+    tags = local.rg_tags
+}
+
+resource "aws_iam_role_policy" "organizations_role_policy" {
+    name = "organizations-tf-state-management-policy"
+    role = aws_iam_role.organizations_role.id
+
+    policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+            {
+                Sid = "StateBucketFullAccess"
+                Action = [
+                    "s3:*"
+                ]
+                Effect = "Allow"
+                Resource = [aws_s3_bucket.state_bucket.arn]
+            },
+            {
+                Sid = "StateBucketDeleteDeny"
+                Action = [
+                    "s3:DeleteBucket",
+                    "s3:CopyObject"
+                ]
+                Effect = "Deny"
+                Resource = [aws_s3_bucket.state_bucket.arn]
+            },
+            {
+                Sid = "AllowSecretRead"
+                Action = [
+                    "secretsmanager:GetSecretValue",
+                    "secretsmanager:DescribeSecret",
+                    "secretsmanager:GetResourcePolicy"
+
+                ]
+                Effect = "Allow"
+                Resource = "*"
+                Condition = {
+                    StringEquals = {
+                        "secretsmanager:ResourceTag/Purpose" = local.rg_tags["Purpose"]
+                    }
+                }
+            },
+            {
+                Sid = "AllowDynamoDBActionsOnLockTable"
+                Effect = "Allow",
+                Action = [
+                    "dynamodb:DescribeTable",
+                    "dynamodb:GetItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:DeleteItem"
+                ],
+                Resource = [ aws_dynamodb_table.state_lock_table.arn ]
+            }
+        ]
+    })
+}

--- a/modules/github-aws-oidc/outputs.tf
+++ b/modules/github-aws-oidc/outputs.tf
@@ -1,0 +1,14 @@
+output "s3_bucket_name" {
+  description = "The name of the s3 bucket holding terraform state."
+  value = aws_s3_bucket.state_bucket.bucket
+}
+
+output "s3_bucket_region" {
+  description = "The region the s3 bucket holding terraform state was created in."
+  value = aws_s3_bucket.state_bucket.region
+}
+
+output "dynamodb_table_name" {
+  description = "The name of the dynamodb table that was created to store lock file ids."
+  value = aws_dynamodb_table.state_lock_table.name
+}

--- a/modules/github-aws-oidc/outputs.tf
+++ b/modules/github-aws-oidc/outputs.tf
@@ -12,3 +12,8 @@ output "dynamodb_table_name" {
   description = "The name of the dynamodb table that was created to store lock file ids."
   value = aws_dynamodb_table.state_lock_table.name
 }
+
+output "organizations_runner_role" {
+  description = "The ARN of the role that the github action runner should assume for the organizations repo"
+  value = aws_iam_role.organizations_role.arn
+}

--- a/modules/github-aws-oidc/resource_group.tf
+++ b/modules/github-aws-oidc/resource_group.tf
@@ -1,0 +1,17 @@
+locals {
+  rg_tags = {
+    Purpose = "Github Foundations"
+  }
+}
+
+# resource  "aws_resourcegroups_group" "github_foundations_rg" {
+#   name = var.rg_name
+
+#   resource_query {
+#     query = <<JSON
+#     {
+
+#     }
+#     JSON
+#   }
+# }

--- a/modules/github-aws-oidc/resource_group.tf
+++ b/modules/github-aws-oidc/resource_group.tf
@@ -4,14 +4,18 @@ locals {
   }
 }
 
-# resource  "aws_resourcegroups_group" "github_foundations_rg" {
-#   name = var.rg_name
+resource  "aws_resourcegroups_group" "github_foundations_rg" {
+  name = var.rg_name
 
-#   resource_query {
-#     query = <<JSON
-#     {
-
-#     }
-#     JSON
-#   }
-# }
+  resource_query {
+    query = jsonencode({
+        "ResourceTypeFilters" = [ "AWS::AllSupported" ]
+        "TagFilters" = [
+            {
+                "Key"="Purpose"
+                "Values"=[ local.rg_tags.Purpose ]
+            }
+        ]
+    })
+  }
+}

--- a/modules/github-aws-oidc/storage.tf
+++ b/modules/github-aws-oidc/storage.tf
@@ -1,0 +1,43 @@
+resource "aws_kms_key" "encryption_key" {
+  description             = "This key is used to encrypt state bucket objects"
+  deletion_window_in_days = 10
+}
+
+resource "aws_s3_bucket" "state_bucket" {
+  bucket = var.bucket_name
+
+  tags = local.rg_tags
+}
+
+resource "aws_s3_bucket_versioning" "state_bucket_versioning" {
+  bucket = aws_s3_bucket.state_bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "state_bucket_encryption" {
+  bucket = aws_s3_bucket.state_bucket.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      kms_master_key_id = aws_kms_key.encryption_key.arn
+      sse_algorithm     = "aws:kms"
+    }
+  }
+}
+
+resource "aws_dynamodb_table" "state_lock_table" {
+  name           = var.tflock_db_name
+  read_capacity  = var.tflock_db_read_capacity
+  write_capacity = var.tflock_db_write_capacity
+  billing_mode   = var.tflock_db_billing_mode
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = local.rg_tags
+}

--- a/modules/github-aws-oidc/variables.tf
+++ b/modules/github-aws-oidc/variables.tf
@@ -1,0 +1,65 @@
+# Resource Group Variables
+variable "rg_name" {
+  type = string
+  description = "The name of the AWS resource group to create for github foundation resources."
+  default = "GithubFoundationResources"
+}
+
+# Bucket Variables
+variable "bucket_name" {
+  type = string
+  description = "The name of the s3 bucket that will store terraform state."
+  default = "GithubFoundationState"
+}
+
+# DynamoDB Variables
+variable "tflock_db_name" {
+  type = string
+  description = "The name of the dynamodb table that will store lock file ids."
+  default = "TFLockIds"
+}
+
+variable "tflock_db_read_capacity" {
+  type = number
+  description = "The read capacity to set for the dynamodb table storing lock file ids. Only required if billing mode is `PROVISIONED`. Defaults to 20."
+  default = 20
+}
+
+variable "tflock_db_write_capacity" {
+  type = number
+  description = "The write capacity to set for the dynamodb table storing lock file ids. Only required if billing mode is `PROVISIONED`. Defaults to 20."
+}
+
+variable "tflock_db_billing_mode" {
+  type = string
+  description = "The billing mode to use for the dynamodb table storing lock file ids. Defaults to `PROVISIONED`."
+  default = "PROVISIONED"
+}
+
+# IAM Variables
+
+variable "github_thumbprints" {
+  type = list(string)
+  description = "A list of top intermediate certifact authority thumbprints to use for setting up an openid connect provider with github. Info on how to obtain thumbprints here: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html"
+  validation {
+    error_message = "The list must be a minimum length of 1 and has a maximum length of 5"
+    condition = length(var.github_thumbprints) >=1 && length(var.github_thumbprints) <= 5
+  }
+}
+
+variable "organizations_role_name" {
+  type = string
+  description = "The name of the role that will be assummed by the github runner for the organizations repository."
+  default = "GhFoundationsOrganizationsAction"
+}
+
+variable "github_repo_owner" {
+  type = string
+  description = "The owner of the github foundations organizations repository. This value should be whatever github account you plan to make the repository under."
+}
+
+variable "organizations_repo_name" {
+  type = string
+  description = "The name of the github foundations organizations repository. Defaults to `organizations`"
+  default = "organizations"
+}

--- a/modules/github-aws-oidc/versions.tf
+++ b/modules/github-aws-oidc/versions.tf
@@ -1,9 +1,9 @@
 terraform {
   required_version = ">= 1.6"
   required_providers {
-    azurerm = {
-      source  = "hashicorp/azurerm"
-      version = ">=3.0.0" #tftest
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/github-azure-oidc/README.md
+++ b/modules/github-azure-oidc/README.md
@@ -4,7 +4,6 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=3.0.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 3.77 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
 ## Providers


### PR DESCRIPTION
Adds a module to setup oidc with AWS. The module creates the following resources:
- A s3 bucket with encryption, and bucket versioning for the terraform state
- A KMS key to use for s3 encryption
- A dynamodb table to enable state locking on the aws terraform backend 
- An openid connect provider for github actions.
- A role for the github actions to assume with web identity
- A role policy allowing the role the necessary permissions to run terraform plans and applies
- A resource group to help manage gh foundation resources.