### PR TITLE
feat: combine `github_team_membership` resource blocks into one

### DIFF
--- a/modules/team/README.md
+++ b/modules/team/README.md
@@ -20,8 +20,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [github_team.team](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team) | resource |
-| [github_team_membership.maintainers](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership) | resource |
-| [github_team_membership.members](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership) | resource |
+| [github_team_membership.memberships](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/team_membership) | resource |
 
 ## Inputs
 

--- a/modules/team/members.tf
+++ b/modules/team/members.tf
@@ -1,17 +1,16 @@
 locals {
   team_id = local.create_team ? github_team.team[0].id : var.team_id
+  
+  # Combine team_maintainers and team_members into a single map with respective roles
+  memberships = merge(
+    { for username in var.team_maintainers : username => "maintainer" },
+    { for username in var.team_members : username => "member" }
+  )
 }
 
-resource "github_team_membership" "maintainers" {
-  for_each = toset(var.team_maintainers)
+resource "github_team_membership" "memberships" {
+  for_each = local.memberships
   team_id  = local.team_id
-  username = each.value
-  role     = "maintainer"
-}
-
-resource "github_team_membership" "members" {
-  for_each = toset(var.team_members)
-  team_id  = local.team_id
-  username = each.value
-  role     = "member"
+  username = each.key
+  role     = each.value
 }

--- a/modules/team/members.tf
+++ b/modules/team/members.tf
@@ -2,9 +2,10 @@ locals {
   team_id = local.create_team ? github_team.team[0].id : var.team_id
   
   # Combine team_maintainers and team_members into a single map with respective roles
+  # If a user appears in both lists, `maintainer` role takes precedence
   memberships = merge(
-    { for username in var.team_maintainers : username => "maintainer" },
-    { for username in var.team_members : username => "member" }
+    { for username in var.team_members : username => "member" },
+    { for username in var.team_maintainers : username => "maintainer" }
   )
 }
 

--- a/modules/team/team.tftest.hcl
+++ b/modules/team/team.tftest.hcl
@@ -16,31 +16,31 @@ run "team_test" {
   command = apply
 
   assert {
-    condition     = github_team_membership.maintainers[var.team_maintainers[0]].team_id == var.team_id
-    error_message = "The maintainer's team id is incorrect. Expected: ${var.team_id}, Actual: ${github_team_membership.maintainers[var.team_maintainers[0]].team_id}"
+    condition     = github_team_membership.memberships[var.team_maintainers[0]].team_id == var.team_id
+    error_message = "The maintainer's team id is incorrect. Expected: ${var.team_id}, Actual: ${github_team_membership.memberships[var.team_maintainers[0]].team_id}"
   }
   assert {
-    condition     = github_team_membership.maintainers[var.team_maintainers[0]].username == var.team_maintainers[0]
-    error_message = "The maintainer's username is incorrect. Expected: ${var.team_maintainers[0]}, Actual: ${github_team_membership.maintainers[var.team_maintainers[0]].username}"
+    condition     = github_team_membership.memberships[var.team_maintainers[0]].username == var.team_maintainers[0]
+    error_message = "The maintainer's username is incorrect. Expected: ${var.team_maintainers[0]}, Actual: ${github_team_membership.memberships[var.team_maintainers[0]].username}"
   }
   assert {
-    condition     = github_team_membership.maintainers[var.team_maintainers[0]].role == "maintainer"
-    error_message = "The maintainer's role is incorrect. Expected: maintainer, Actual: ${github_team_membership.maintainers[var.team_maintainers[0]].role}"
+    condition     = github_team_membership.memberships[var.team_maintainers[0]].role == "maintainer"
+    error_message = "The maintainer's role is incorrect. Expected: maintainer, Actual: ${github_team_membership.memberships[var.team_maintainers[0]].role}"
   }
 }
 
 run "team_member_test" {
   assert {
-    condition     = github_team_membership.members[var.team_members[0]].team_id == var.team_id
-    error_message = "The member's team id is incorrect. Expected: ${var.team_id}, Actual: ${github_team_membership.members[var.team_members[0]].team_id}"
+    condition     = github_team_membership.memberships[var.team_members[0]].team_id == var.team_id
+    error_message = "The member's team id is incorrect. Expected: ${var.team_id}, Actual: ${github_team_membership.memberships[var.team_members[0]].team_id}"
   }
   assert {
-    condition     = github_team_membership.members[var.team_members[0]].username == var.team_members[0]
-    error_message = "The member's username is incorrect. Expected: ${var.team_members[0]}, Actual: ${github_team_membership.members[var.team_members[0]].username}"
+    condition     = github_team_membership.memberships[var.team_members[0]].username == var.team_members[0]
+    error_message = "The member's username is incorrect. Expected: ${var.team_members[0]}, Actual: ${github_team_membership.memberships[var.team_members[0]].username}"
   }
   assert {
-    condition     = github_team_membership.members[var.team_members[0]].role == "member"
-    error_message = "The member's role is incorrect. Expected: member, Actual: ${github_team_membership.members[var.team_members[0]].role}"
+    condition     = github_team_membership.memberships[var.team_members[0]].role == "member"
+    error_message = "The member's role is incorrect. Expected: member, Actual: ${github_team_membership.memberships[var.team_members[0]].role}"
   }
 
 }


### PR DESCRIPTION
Combine separate `github_team_membership` resource blocks for maintainers and members into one. This simplifies making changes when reconciling drift in membership. 

Consider the following example, terraform plan suggests an _update in-place_ -
  ```hcl
  [projects/copilot/FociSolutions/teams]
  Terraform used the selected providers to generate the following execution
  plan. Resource actions are indicated with the following symbols:
    ~ update in-place
  Terraform will perform the following actions:
    # module.team["copilot-enabled"].github_team_membership.members["yeybr"] will be updated in-place
    ~ resource "github_team_membership" "members" {
          id       = "12815562:yeybr"
        ~ role     = "maintainer" -> "member"
          # (3 unchanged attributes hidden)
      }
  ```

However, following the suggestion from the previous plan and moving `yeybr` from the `maintainers` to `members` list, instead results in a _destroy + create_, like so -
  ```hcl
  [projects/copilot/FociSolutions/teams]
  Terraform used the selected providers to generate the following execution
  plan. Resource actions are indicated with the following symbols:
    + create
    - destroy
  Terraform will perform the following actions:
    # module.team["copilot-enabled"].github_team_membership.maintainers["yeybr"] will be created
    + resource "github_team_membership" "maintainers" {
        + etag     = (known after apply)
        + id       = (known after apply)
        + role     = "maintainer"
        + team_id  = "12815562"
        + username = "yeybr"
      }
        # module.team["copilot-enabled"].github_team_membership.members["yeybr"] will be destroyed
    # (because key ["yeybr"] is not in for_each map)
    - resource "github_team_membership" "members" {
        - etag     = "W/\"30d522f7bff4946d257244fb97e69ad8da9049cbea62956e11b739c376d67344\"" -> null
        - id       = "12815562:yeybr" -> null
        - role     = "maintainer" -> null
        - team_id  = "12815562" -> null
        - username = "yeybr" -> null
      }
  ```

This is likely due to having separate resource definitions for each role. This PR combines the resource definitions into one via an intermediate local variable to transform the list of maintainers and members, into a single key-value pair of `username => role`. As a result, any suggestions for `update in-place` can be resolved by moving users to the right list.