### PR TITLE
fix: propagate `integrations` instead of `repository_roles`

### DIFF
--- a/modules/repository_base/rulesets.tf
+++ b/modules/repository_base/rulesets.tf
@@ -93,7 +93,7 @@ module "ruleset" {
       user_id       = data.github_user.branch_ruleset_bypasser[bypasser.user].id
       always_bypass = bypasser.always_bypass
     }]
-    integrations = try(each.value.bypass_actors.repository_roles, [])
+    integrations = try(each.value.bypass_actors.integrations, [])
   }
 
   ref_name_inclusions = each.value.conditions.ref_name.include


### PR DESCRIPTION
Propagate `integrations` instead of `repository_roles`, the `repository_roles` being propagated down to integrations causes an `Invalid value` error when defining rulesets. Excerpt from the [failed CI job](https://github.com/foci-github-foundations/organizations/actions/runs/18177363316/job/51746185587#step:8:2357) - 
```hcl
  │ Error: Invalid value for input variable
  │ 
  │   on ../repository_base/rulesets.tf line 83, in module "ruleset":
  │   83:   bypass_actors = {
  │   84:     repository_roles = [for bypasser in try(toset(coalesce(each.value.bypass_actors.repository_roles, [])), []) : {
  │   85:       role_id       = lookup(local.github_base_role_ids, bypasser.role, data.github_organization_custom_role.branch_ruleset_bypasser[bypasser.role].id)
  │   86:       always_bypass = bypasser.always_bypass
  │   87:     }]
  │   88:     teams = [for bypasser in try(toset(coalesce(each.value.bypass_actors.teams, [])), []) : {
  │   89:       team_id       = data.github_team.branch_ruleset_bypasser[bypasser.team].id
  │   90:       always_bypass = bypasser.always_bypass
  │   91:     }]
  │   92:     organization_admins = [for bypasser in try(toset(coalesce(each.value.bypass_actors.organization_admins, [])), []) : {
  │   93:       user_id       = data.github_user.branch_ruleset_bypasser[bypasser.user].id
  │   94:       always_bypass = bypasser.always_bypass
  │   95:     }]
  │   96:     integrations = try(each.value.bypass_actors.repository_roles, [])
  │   97:   }
  │ 
  │ The given value is not suitable for
  │ module.private_repositories["litellm-admin"].module.repository_base.module.ruleset["protected_branches"].var.bypass_actors
  │ declared at ../ruleset/variables.tf:6,1-25: attribute "integrations":
  │ incorrect list element type: attribute "installation_id" is required.
  ╵
```